### PR TITLE
Support recent CentOS Stream 9 kernels

### DIFF
--- a/vmmon-only/Makefile
+++ b/vmmon-only/Makefile
@@ -140,6 +140,15 @@ ifdef VMX86_DEBUG
 CC_OPTS += -DVMX86_DEBUG
 endif
 
+# Make Centos Strem 9 kernel release avaialble to preprocessor
+ifndef CS9_RELEASE
+CS9_RELEASE := $(shell uname -r | sed -n 's/5.14.0-\([[:digit:]]\+\).el9.x86_64$$/\1/p')
+ifdef CS9_RELEASE
+$(info CS9_RELEASE is $(CS9_RELEASE))
+CC_OPTS += -DKRHEL_RELEASE=$(CS9_RELEASE)
+endif
+endif
+
 # Add Spectre options when available
 
 include $(SRCROOT)/Makefile.kernel

--- a/vmmon-only/include/pgtbl.h
+++ b/vmmon-only/include/pgtbl.h
@@ -47,7 +47,11 @@
  *-----------------------------------------------------------------------------
  */
 
-#if COMPAT_LINUX_VERSION_CHECK_LT(6, 5, 0) // only used by PgtblVa2MPN() below
+// Fails to compile on CentOS Stream 9 kernel release 547
+//#ifndef KHREL_RELEASE
+#define NOCS9_OR_LT547 (! defined(KRHEL_RELEASE)) || (KRHEL_RELEASE < 547)
+
+#if COMPAT_LINUX_VERSION_CHECK_LT(6, 5, 0) && NOCS9_OR_LT547 // only used by PgtblVa2MPN() below
 static INLINE MPN
 PgtblVa2MPNLocked(struct mm_struct *mm, // IN: Mm structure of a process
                   VA addr)              // IN: Address in the virtual address
@@ -129,7 +133,7 @@ PgtblVa2MPNLocked(struct mm_struct *mm, // IN: Mm structure of a process
  *-----------------------------------------------------------------------------
  */
 
-#if COMPAT_LINUX_VERSION_CHECK_LT(6, 5, 0)
+#if COMPAT_LINUX_VERSION_CHECK_LT(6, 5, 0) && NOCS9_OR_LT547
 
 static INLINE MPN
 PgtblVa2MPN(VA addr)  // IN

--- a/vmnet-only/Makefile
+++ b/vmnet-only/Makefile
@@ -140,6 +140,15 @@ ifdef VMX86_DEBUG
 CC_OPTS += -DVMX86_DEBUG
 endif
 
+# Make Centos Strem 9 kernel release avaialble to preprocessor
+ifndef CS9_RELEASE
+CS9_RELEASE := $(shell uname -r | sed -n 's/5.14.0-\([[:digit:]]\+\).el9.x86_64$$/\1/p')
+ifdef CS9_RELEASE
+$(info CS9_RELEASE is $(CS9_RELEASE))
+CC_OPTS += -DKRHEL_RELEASE=$(CS9_RELEASE)
+endif
+endif
+
 # Add Spectre options when available
 
 include $(SRCROOT)/Makefile.kernel

--- a/vmnet-only/userif.c
+++ b/vmnet-only/userif.c
@@ -544,9 +544,13 @@ VNetCsumAndCopyToUser(const void *src,   // IN: Source
 {
    unsigned int csum;
 
+// CentOS Strean 9 uses kernel 5.14.0. Release 437 and later don't use csum_and_copy_to_user
+// Need to find a way to test
+#define CENTOS_9_CSUM(s) 0
+
 #if COMPAT_LINUX_VERSION_CHECK_LT(5, 10, 0)
    csum = csum_and_copy_to_user(src, dst, len, 0, err);
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0) && CENTOS_9_CSUM(RHEL_RELEASE)
    csum = csum_and_copy_to_user(src, dst, len);
    *err = (csum == 0) ? -EFAULT : 0;
 #else

--- a/vmnet-only/userif.c
+++ b/vmnet-only/userif.c
@@ -545,12 +545,11 @@ VNetCsumAndCopyToUser(const void *src,   // IN: Source
    unsigned int csum;
 
 // CentOS Strean 9 uses kernel 5.14.0. Release 437 and later don't use csum_and_copy_to_user
-// Need to find a way to test
-#define CENTOS_9_CSUM(s) 0
+#define CS9_CSUM (!defined(KRHEL_RELEASE) || (KRHEL_RELEASE < 437))
 
 #if COMPAT_LINUX_VERSION_CHECK_LT(5, 10, 0)
    csum = csum_and_copy_to_user(src, dst, len, 0, err);
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0) && CENTOS_9_CSUM(RHEL_RELEASE)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0) && CS9_CSUM
    csum = csum_and_copy_to_user(src, dst, len);
    *err = (csum == 0) ? -EFAULT : 0;
 #else

--- a/vmnet-only/vmnetInt.h
+++ b/vmnet-only/vmnetInt.h
@@ -42,17 +42,14 @@
     dev_queue_xmit(skb)                                   \
   )
 
-// need to find a way to test that RHEL_RELEASE >= 522
-#define CENTOS_9_RCU(s) 1
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0)) || CENTOS_9_RCU(RHEL_RELEASE)
+// Centos Stream 9 uses kernel 5.14.0 but releases 522 and above use rcu_read_lock()
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0)) || (defined(KRHEL_RELEASE) && (KRHEL_RELEASE >= 522))
 #   define dev_lock_list()    rcu_read_lock()
 #   define dev_unlock_list()  rcu_read_unlock()
 #else
 #   define dev_lock_list()    read_lock(&dev_base_lock)
 #   define dev_unlock_list()  read_unlock(&dev_base_lock)
 #endif
-
 
 extern struct proto vmnet_proto;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 2, 0) || defined(sk_net_refcnt)

--- a/vmnet-only/vmnetInt.h
+++ b/vmnet-only/vmnetInt.h
@@ -41,7 +41,11 @@
     compat_skb_set_network_header(skb, sizeof (struct ethhdr)),  \
     dev_queue_xmit(skb)                                   \
   )
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0)
+
+// need to find a way to test that RHEL_RELEASE >= 522
+#define CENTOS_9_RCU(s) 1
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0)) || CENTOS_9_RCU(RHEL_RELEASE)
 #   define dev_lock_list()    rcu_read_lock()
 #   define dev_unlock_list()  rcu_read_unlock()
 #else

--- a/vmnet-only/vnetInt.h
+++ b/vmnet-only/vnetInt.h
@@ -47,7 +47,9 @@
 #define LOG(level, args)
 #endif
 
+#ifndef MAX
 #define MAX(_a, _b)   (((_a) > (_b)) ? (_a) : (_b))
+#endif
 
 /*
  * Ethernet


### PR DESCRIPTION
CentOS Stream 9 uses kernel 5.14.0, but changes in later kernels are backported. This change modifies the preprocessor kernel version tests to work properly with CentOS Stream 9.